### PR TITLE
Simplify the System record by only retaining planet ids

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -85,7 +85,24 @@ pub(crate) async fn save_system(graph: &Arc<Graph>, system: &System) -> Result<(
 #[cfg(test)]
 mod tests {
     use reqwest::Client;
-    use crate::database::get_stargate;
+    use crate::database::{get_graph_client, get_stargate, get_system_details, save_system};
+
+    #[tokio::test]
+    async fn can_save_system_to_database() {
+        let client = Client::new();
+        let graph = get_graph_client().await;
+
+        let system_id = 30000201;
+        let system = get_system_details(&client, system_id).await.unwrap();
+
+        match save_system(&graph, &system).await {
+            Ok(_) => {
+                //TODO: Delete the record created
+            }
+            Err(_) => panic!("Could not save system")
+        }
+
+    }
 
     #[tokio::test]
     async fn can_retrieve_and_parse_stargate() {

--- a/src/database.rs
+++ b/src/database.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use futures::StreamExt;
 use neo4rs::{Graph, query};
-use reqwest::Client;
+use crate::esi::SystemEsiResponse;
 
-use crate::models::{Stargate, System};
+use crate::models::{System};
 
 pub(crate) async fn get_graph_client() -> Arc<Graph> {
     let uri = "bolt://localhost:7687";
@@ -13,23 +13,25 @@ pub(crate) async fn get_graph_client() -> Arc<Graph> {
     Arc::new(Graph::new(uri, user, pass).await.unwrap())
 }
 
-pub(crate) async fn get_system_details(client: &Client, system_id: i64) -> Result<System, reqwest::Error> {
-    let system_detail_url = format!("https://esi.evetech.net/latest/universe/systems/{}", system_id);
-    let response = client.get(&system_detail_url).send().await?;
-    response.json().await
+impl From<SystemEsiResponse> for System {
+    fn from(s: SystemEsiResponse) -> Self {
+        Self {
+            constellation_id: s.constellation_id,
+            name: s.name,
+            planets: s.planets.map(|planets| planets.into_iter().map(|planet| planet.planet_id).collect()),
+            x: s.position.x,
+            y: s.position.y,
+            z: s.position.z,
+            security_class: s.security_class,
+            security_status: s.security_status,
+            star_id: s.star_id,
+            stargates: s.stargates,
+            system_id: s.system_id,
+        }
+    }
 }
 
-pub(crate) async fn get_stargate(client: &Client, stargate_id: i64) -> Result<Stargate, reqwest::Error> {
-    let stargate_url = format!("https://esi.evetech.net/latest/universe/stargates/{}", stargate_id);
-    let response = client.get(&stargate_url).send().await?;
-    response.json().await
-}
 
-pub(crate) async fn get_system_ids(client: &Client) -> Result<Vec<i64>, reqwest::Error> {
-    let systems_url = "https://esi.evetech.net/latest/universe/systems/";
-    let response = client.get(systems_url).send().await?;
-    response.json().await
-}
 
 pub(crate) async fn system_id_exists(graph: &Graph, system_id: i64) -> Result<bool, neo4rs::Error> {
     let system_exists = "MATCH (s:System {system_id: $system_id}) RETURN COUNT(s) as count LIMIT 1";
@@ -72,9 +74,9 @@ pub(crate) async fn save_system(graph: &Arc<Graph>, system: &System) -> Result<(
         .param("security_status", system.security_status)
         .param("star_id", star_id)
         .param("security_class", security_class_param)
-        .param("x", system.position.x)
-        .param("y", system.position.y)
-        .param("z", system.position.z)
+        .param("x", system.x)
+        .param("y", system.y)
+        .param("z", system.z)
         .param("planets", planets_json)
         .param("stargates", stargates))
         .await?;
@@ -85,7 +87,9 @@ pub(crate) async fn save_system(graph: &Arc<Graph>, system: &System) -> Result<(
 #[cfg(test)]
 mod tests {
     use reqwest::Client;
-    use crate::database::{get_graph_client, get_stargate, get_system_details, save_system};
+
+    use crate::database::{get_graph_client, save_system};
+    use crate::esi::{get_stargate, get_system_details};
 
     #[tokio::test]
     async fn can_save_system_to_database() {
@@ -101,7 +105,6 @@ mod tests {
             }
             Err(_) => panic!("Could not save system")
         }
-
     }
 
     #[tokio::test]

--- a/src/esi.rs
+++ b/src/esi.rs
@@ -1,0 +1,66 @@
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use crate::models::System;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct SystemEsiResponse {
+    pub constellation_id: Option<i64>,
+    pub name: Option<String>,
+    pub planets: Option<Vec<Planet>>,
+    pub position: Position,
+    pub security_class: Option<String>,
+    pub security_status: f64,
+    pub star_id: Option<i64>,
+    pub stargates: Option<Vec<i64>>,
+    pub system_id: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub(crate) struct Planet {
+    pub planet_id: i64,
+    pub asteroid_belts: Option<Vec<i64>>,
+    pub moons: Option<Vec<i64>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Position {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Stargate {
+    pub destination: Destination,
+    pub name: String,
+    pub position: Position,
+    pub stargate_id: i64,
+    pub system_id: i64,
+    pub type_id: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct Destination {
+    stargate_id: i64,
+    system_id: i64,
+}
+
+pub(crate) async fn get_system_details(client: &Client, system_id: i64) -> Result<System, reqwest::Error> {
+    let system_detail_url = format!("https://esi.evetech.net/latest/universe/systems/{}", system_id);
+    let response = client.get(&system_detail_url).send().await?;
+    let system_esi_response: SystemEsiResponse = response.json().await?;
+
+    Ok(System::from(system_esi_response))
+}
+
+pub(crate) async fn get_stargate(client: &Client, stargate_id: i64) -> Result<Stargate, reqwest::Error> {
+    let stargate_url = format!("https://esi.evetech.net/latest/universe/stargates/{}", stargate_id);
+    let response = client.get(&stargate_url).send().await?;
+    response.json().await
+}
+
+pub(crate) async fn get_system_ids(client: &Client) -> Result<Vec<i64>, reqwest::Error> {
+    let systems_url = "https://esi.evetech.net/latest/universe/systems/";
+    let response = client.get(systems_url).send().await?;
+    response.json().await
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,12 @@ use std::sync::Arc;
 use neo4rs::Graph;
 use reqwest::Client;
 
-use crate::database::{get_graph_client, get_system_details, get_system_ids, save_system, system_id_exists};
+use crate::database::{get_graph_client, save_system, system_id_exists};
+use crate::esi::{get_system_details, get_system_ids};
 
 mod models;
 mod database;
+mod esi;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>>{

--- a/src/models.rs
+++ b/src/models.rs
@@ -21,6 +21,22 @@ pub(crate) struct Planet {
 }
 
 #[derive(Debug, Deserialize)]
+pub(crate) struct Stargate {
+    pub destination: Destination,
+    pub name: String,
+    pub position: Position,
+    pub stargate_id: i64,
+    pub system_id: i64,
+    pub type_id: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct Destination {
+    stargate_id: i64,
+    system_id: i64,
+}
+
+#[derive(Debug, Deserialize)]
 pub(crate) struct Position {
     pub x: f64,
     pub y: f64,

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,11 +1,13 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct System {
     pub constellation_id: Option<i64>,
     pub name: Option<String>,
-    pub planets: Option<Vec<Planet>>,
-    pub position: Position,
+    pub planets: Option<Vec<i64>>,
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
     pub security_class: Option<String>,
     pub security_status: f64,
     pub star_id: Option<i64>,
@@ -13,32 +15,3 @@ pub(crate) struct System {
     pub system_id: i64,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub(crate) struct Planet {
-    planet_id: i64,
-    asteroid_belts: Option<Vec<i64>>,
-    moons: Option<Vec<i64>>,
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct Stargate {
-    pub destination: Destination,
-    pub name: String,
-    pub position: Position,
-    pub stargate_id: i64,
-    pub system_id: i64,
-    pub type_id: i64,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub(crate) struct Destination {
-    stargate_id: i64,
-    system_id: i64,
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct Position {
-    pub x: f64,
-    pub y: f64,
-    pub z: f64,
-}


### PR DESCRIPTION
While trying to read a System from the database, I discovered the inherent difficulty of hydrating a complex object that had been flattened when saved. It occurred to me that we need not save the whole planet structure with the System as the planets themselves will later become nodes with relations to System nodes, thus saving the planet ids on the System record should suffice.